### PR TITLE
Add assertions to document assumptions

### DIFF
--- a/src/main/java/cs2103t/ip/duke/Duke.java
+++ b/src/main/java/cs2103t/ip/duke/Duke.java
@@ -166,6 +166,7 @@ public class Duke extends Application {
      */
     private String getResponse(String input) throws IOException {
         int index = tasks.size();
+        assert input.length() > 0 : "Error! No input";
             if (parser.isBye(input)) {
                 for (int i = 0; i < tasks.size(); i++) {
                     Task task = tasks.getTasks().get(i);


### PR DESCRIPTION
User is allowed to enter empty message with no input.

Throwing an error to disallow users to enter an empty message will make it more user-friendly since it avoids confusing the users when an empty message body is shown.

Let's
* add an assertion to ensure that the user input length is more than 0, else an error will be thrown